### PR TITLE
update o3de-liveplusplus gem to latest o3de changes

### DIFF
--- a/Code/CMakeLists.txt
+++ b/Code/CMakeLists.txt
@@ -5,7 +5,7 @@
 #       in which case it will see if that platform is present here or in the restricted folder.
 #       i.e. It could here in our gem : Gems/LivePlusPlus/Code/Platform/<platorm_name>  or
 #            <restricted_folder>/<platform_name>/Gems/LivePlusPlus/Code
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} ${o3de_gem_restricted_path} ${o3de_gem_path} ${o3de_gem_name})
+o3de_pal_dir(pal_dir "${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME}" "${o3de_gem_restricted_path}" "${o3de_gem_path}" "${o3de_gem_name}")
 
 # Now that we have the platform abstraction layer (PAL) folder for this folder, thats where we will find the
 # traits for this platform. Traits for a platform are defines for things like whether or not something in this gem


### PR DESCRIPTION
`ly_get_list_relative_pal_filename` is marked as deprecated and `o3de_pal_dir` is recommended to be used instead.

`o3de_pal_dir` also expects all arguments to be quoted otherwise it complains that the wrong number of arguments have been passed to the command.